### PR TITLE
Revert "Remove ocamlfind"

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.8.1+dune/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.1+dune/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo: "git+https://github.com/dune-universe/lib-findlib.git#duniverse-1.8.1"
+build: [
+  [ "env" "FINDLIB_PREFIX=%{lib}%" "dune" "build" "-p" name "-j" jobs ]
+]
+install: [
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+  ["cp" "%{lib}%/toplevel/topfind" "%{lib}%/ocaml/topfind"] {!ocaml:preinstalled}
+]
+remove: [
+  ["rm" "-f" "%{bin}%/ocaml"] {ocaml:preinstalled}
+  ["rm" "-f" "%{lib}%/ocaml/topfind"] {!ocaml:preinstalled}
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"
+  "findlib"
+]
+setenv: OCAMLPATH = "%{lib}%"
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+url {
+  src: "https://github.com/dune-universe/lib-findlib/archive/v1.8.1+dune.tar.gz"
+  checksum: "sha256=1a337aaedca94837d4d6a1689ed18109e4a2cfd4aa99a56252a6f19fe1291bb0"
+}


### PR DESCRIPTION
This reverts commit 3dd96b0560cbf912f0a62cc9a625e9b763381987.

Due to `ppx_deriving.5.2.1`, we still need a dunified version of `ocamlfind` to be able to compile an _unikernel_.